### PR TITLE
允许 Response 一栏值为空

### DIFF
--- a/background.js
+++ b/background.js
@@ -40,7 +40,7 @@ chrome.webRequest.onBeforeRequest.addListener(function (details) {
         var url = details.url;
         for (var i = 0, len = ReResMap.length; i < len; i++) {
             var reg = new RegExp(ReResMap[i].req, 'gi');
-            if (ReResMap[i].checked && ReResMap[i].res && reg.test(url)) {
+            if (ReResMap[i].checked && typeof ReResMap[i].res === 'string' && reg.test(url)) {
                 if (!/^file:\/\//.test(ReResMap[i].res)) {
 //                    return ReResMap[i].type === 'file' ?
 //                    {redirectUrl: ReResMap[i].res} :

--- a/js/options.js
+++ b/js/options.js
@@ -47,8 +47,8 @@ reres.controller('mapListCtrl', function($scope) {
 
     //验证输入合法性
     $scope.virify = function () {
-        if (!$scope.curRule.req || !$scope.curRule.res) {
-            $scope.inputError = '输入不能为空';
+        if (!$scope.curRule.req) {
+            $scope.inputError = '正则一栏输入不能为空';
             return false;
         }
         try {

--- a/js/popup.js
+++ b/js/popup.js
@@ -56,8 +56,8 @@ reres.controller('mapListCtrl', function ($scope) {
 
     //验证输入合法性
     $scope.virify = function () {
-        if (!$scope.curRule.req || !$scope.curRule.res) {
-            $scope.inputError = '输入不能为空';
+        if (!$scope.curRule.req) {
+            $scope.inputError = '正则一栏输入不能为空';
             return false;
         }
         try {


### PR DESCRIPTION
ReRes 应该允许 Response 为空，这样能够用于过滤特定内容（比如以下追踪参数）
````
recommend_source|red_tag|visit_id|seid|spm_id_from|from_source|tdsourcetag|share_medium|share_source|bbid|spm|utm\_[a-z]+|jd_pop|qq-pf-to
````